### PR TITLE
fix: mac build

### DIFF
--- a/server/dict_server.hpp
+++ b/server/dict_server.hpp
@@ -6,7 +6,9 @@
 #include <strings.h>
 #include <sys/select.h>
 #include <sys/types.h>
+#ifdef __linux__
 #include <sys/epoll.h>
+#endif /* ifdef __linux__ */
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>


### PR DESCRIPTION
修复 mac 下编译找不到 `sys/epoll.h` 头文件问题